### PR TITLE
Fix: Correct base URL for GitHub custom domain

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import tailwind from "@astrojs/tailwind";
 // https://astro.build/config
 export default defineConfig({
   site: 'https://academysoftwarefoundation.github.io',
-  base: '/dpel-website',
+  base: '/',
   // Will setup any new pages to be unpublished till draft is done
   markdown: {
     drafts: true,

--- a/src/component/Breadcrumbs.astro
+++ b/src/component/Breadcrumbs.astro
@@ -22,7 +22,7 @@ let parts = [
   {
     text: 'Home',
     href: BASE_URL,
-    'aria-current': Astro.url?.pathname === '/dpel-website' ? 'page' : undefined
+    'aria-current': Astro.url?.pathname === '/' ? 'page' : undefined
   }
 ];
 

--- a/src/component/Button.astro
+++ b/src/component/Button.astro
@@ -27,7 +27,7 @@ const { text, cardBtnVisible, type, url } = Astro.props;
 
 const checkUrl = (url) => {
   const splitUrl = url.split(':').includes('https');
-  if (!splitUrl && !url.includes("/dpel-website/")) {
+  if (!splitUrl && !url.includes("/")) {
     url = BASE_URL + url
   }
   return url;

--- a/src/content/license/alab-license.md
+++ b/src/content/license/alab-license.md
@@ -9,9 +9,9 @@ titleAlt: "ALab License"
 blogTitleAlt: "ALab"
 
 # Links for the buttons: Back and Home
-homePageUrl: "/dpel-website/"
-previousPageUrl: "/dpel-website/alab"
-nextPageUrl: "/dpel-website/alab/alab-license"
+homePageUrl: "/"
+previousPageUrl: "/alab"
+nextPageUrl: "/alab/alab-license"
 
 # License text. Each sentence is broken up by commas.
 licenseContent: [

--- a/src/content/license/alab-trailer-license.md
+++ b/src/content/license/alab-trailer-license.md
@@ -4,9 +4,9 @@ title: "ASWF Digital Assets License v1.1"
 titleAlt: "ALab License"
 blogTitleAlt: "ALab Trailer"
 
-homePageUrl: "/dpel-website/"
-previousPageUrl: "/dpel-website/alab-trailer"
-nextPageUrl: "/dpel-website/alab-trailer/alab-trailer-license"
+homePageUrl: "/"
+previousPageUrl: "/alab-trailer"
+nextPageUrl: "/alab-trailer/alab-trailer-license"
 
 licenseContent: [
   'License for Animal Logic ALab (the "Asset Name").',

--- a/src/content/license/aws-noa-license.md
+++ b/src/content/license/aws-noa-license.md
@@ -4,9 +4,9 @@ title: "ASWF Digital Assets License v1.1"
 titleAlt: "AWS Noa Character License"
 blogTitleAlt: "AWS Noa Character"
 
-homePageUrl: "/dpel-website/"
-previousPageUrl: "/dpel-website/noa"
-nextPageUrl: "/dpel-website/noa/aws-noa-license"
+homePageUrl: "/"
+previousPageUrl: "/noa"
+nextPageUrl: "/noa/aws-noa-license"
 licenseContent: [
   'License for AWS Noa Character (the "Asset Name").',
   "AWS Noa Character Copyright 2022 Amazon Web Services. All rights reserved.",

--- a/src/content/license/intel-volumetric-clouds-license.md
+++ b/src/content/license/intel-volumetric-clouds-license.md
@@ -4,9 +4,9 @@ title: "ASWF Digital Assets License v1.1"
 titleAlt: "Intel Volumetric Clouds License"
 blogTitleAlt: "Intel Volumetric Clouds Library"
 
-homePageUrl: "/dpel-website/"
-previousPageUrl: "/dpel-website/intel-cloud-library"
-nextPageUrl: "/dpel-website/intel-cloud-library/intel-volumetric-clouds-license"
+homePageUrl: "/"
+previousPageUrl: "/intel-cloud-library"
+nextPageUrl: "/intel-cloud-library/intel-volumetric-clouds-license"
 
 licenseContent: [
   'License for Intel® Volumetric Clouds Library (the "Asset Name").',

--- a/src/content/license/moore-lane-license.md
+++ b/src/content/license/moore-lane-license.md
@@ -4,9 +4,9 @@ title: "ASWF Digital Assets License v1.1"
 titleAlt: "Moore Lane License"
 blogTitleAlt: "4004 Moore Lane"
 
-homePageUrl: "/dpel-website/"
-previousPageUrl: "/dpel-website/4004-moore-lane"
-nextPageUrl: "/dpel-website/4004-moore-lane/moore-lane-license"
+homePageUrl: "/"
+previousPageUrl: "/4004-moore-lane"
+nextPageUrl: "/4004-moore-lane/moore-lane-license"
 
 licenseContent: [
   'License for 4004 Moore Lane – USD Scene from Intel® (the "Asset Name").',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -3,7 +3,7 @@
  * Do not delete this file. 
  * This file is used to append onto to any URLs on the site.
  * 
- * Setting "/dpel-website/" as the value is to accommodate for the Github Pages deployment that don't use DPEL's own URL.
+ * Setting "/" as the value is to accommodate for the Github Pages deployment that don't use DPEL's own URL.
  * If using DPEL's own URL, set this to empty ("").
  * 
  * This would essentially append whatever needs to append in front of the image paths, site urls, and button urls.
@@ -12,4 +12,4 @@
  * 
  */
 
-export const BASE_URL = "/dpel-website/";
+export const BASE_URL = "";


### PR DESCRIPTION
The repository has been configured using the custom dpel.aswf.io domain
and now needs to have /dpel-website/ stripped from any URIs

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
