### PR TITLE
Fix AWS Picchu Edit link & README

### DIFF
--- a/src/content/articles/aws-picchu-edit.md
+++ b/src/content/articles/aws-picchu-edit.md
@@ -41,7 +41,7 @@ title: "AWS Picchu Edit"
 # Used mainly for the Breadcrumbs
 titleAlt: "AWS Picchu Edit"
 # The url of the blog page. Please remember to add this base url before you add the rest of the url.
-url: "picchu"
+url: "aws-picchu-edit"
 # The cover image of the blog page
 coverImage: {
   src: "./images/aws-picchu-edit/aws-picchu-edit-still.png",

--- a/src/content/articles/aws-picchu-edit.md
+++ b/src/content/articles/aws-picchu-edit.md
@@ -93,6 +93,12 @@ downloadSection: {
 
   # The download links and button setup for the download table.
   downloads: [{
+    buttonText: "README",
+    downloadUrl: "https://github.com/AcademySoftwareFoundation/OpenTimelineIO/wiki/AWS-Picchu-Edit-OTIO-Conversion-Notes",
+    descriptionBold: "Documentation explaining Resolve to OTIO conversion, caveats, and contact information for questions & feedback.",
+    type: "primary"
+  },
+  {
     buttonText: "DOWNLOAD",
     downloadUrl: "https://dpel-assets.aswf.io/picchu/picchu_v10_az.dra.zip",
     size: "2.9 GB",


### PR DESCRIPTION
This PR fixes a typo which broke the main page link to AWS Picchu Edit, and also adds a link to the README explaining the Resolve to OTIO conversion process.
