### PR TITLE
sort by latest added asset in home page

### DIFF
--- a/src/utils/sortCards.js
+++ b/src/utils/sortCards.js
@@ -1,6 +1,6 @@
 // Sorts the order of the cards on the home page
 export function sortCards(cards) {
   return cards.sort((a, b) =>
-    a.data.order > b.data.order ? 1 : a.data.order < b.data.order ? -1 : 0,
+    a.data.order > b.data.order ? -1 : a.data.order < b.data.order ? 1 : 0
   );
 }


### PR DESCRIPTION
resolves #18 

Reversing the sort order for the asset list on home page to display the latest at the top always