### PR TITLE
Moved Wiki from ARW to DPEL

### DIFF
--- a/src/content/homecards/other-assets.md
+++ b/src/content/homecards/other-assets.md
@@ -6,6 +6,6 @@ title: "Other Assets"
 description: "Here is a short list of"
 link: {
   text: "computer graphics assets available elsewhere.",
-  url: "https://wiki.aswf.io/display/ARW/Links+to+Open+Assets"
+  url: "https://wiki.aswf.io/display/DPEL/Links+to+Open+Assets"
 }
 ---


### PR DESCRIPTION
Updated links to https://wiki.aswf.io from legacy ARW space to new DPEL space