### PR TITLE
ALab-2.2.0 update for 2024 release

### DIFF
--- a/src/content/articles/alab.md
+++ b/src/content/articles/alab.md
@@ -89,18 +89,18 @@ downloadSection: {
   downloads: [{
     buttonText: "DOWNLOAD",
     downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-v2.2.0.zip",
-    size: "9.3 GB",
+    size: "300 MB",
     description: "",
-    descriptionBold: "Asset Structure | ",
+    descriptionBold: "Asset Structure - v.2.2.0 | ",
     extraDescription: "Main asset structure for the ALab showcasing how all assets relate to each other through USD composition arcs. This is purely the USD structure linking all files, and does not include any geometry, shaders or lights.",
     type: "primary"
   },
   {
     buttonText: "DOWNLOAD",
-    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-v2.2.0.zip",
+    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-techvars.v2.2.0.zip
     size: "8.9 GB",
     description: "",
-    descriptionBold: "Techvar Assets | ",
+    descriptionBold: "Techvar Assets - v.2.2.0 | ",
     extraDescription: "Assets holding the heavy creative content from DCCs (geometry, lights, shaders, textures, rigs), which Animal Logic refers to as 'techvar assets'. Merge this with the 'Asset Structure' package to render the ALab with 1k textures and without fur & cloth.",
     type: "primary"
   },
@@ -109,7 +109,7 @@ downloadSection: {
     downloadUrl: "https://aswf-dpel-assets.s3.amazonaws.com/usd-alab/alab-textures.v2.2.0.zip",
     size: "71.4 GB",
     description: "",
-    descriptionBold: "Texture Pack | ",
+    descriptionBold: "Texture Pack - v.2.2.0 | ",
     extraDescription: "4k half float mipmapped OpenEXR textures in ACEScg color space. Merge this to see much higher quality for final rendering.",
     type: "primary"
   },
@@ -118,7 +118,7 @@ downloadSection: {
     downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-cameras.v2.2.0.zip",
     size: "500 KB",
     description: "",
-    descriptionBold: "Cameras | ",
+    descriptionBold: "Cameras - v.2.2.0 | ",
     extraDescription: "Cameras from the ALab Phase 2 trailer. Merge this to be able to select any trailer camera directly from the USD stage.",
     type: "primary"
   },             
@@ -127,7 +127,7 @@ downloadSection: {
     downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-procedurals.v2.2.0.zip",
     size: "18.1 GB",
     description: "",
-    descriptionBold: "Baked Procedurals | ",
+    descriptionBold: "Baked Procedurals - v.2.2.0 | ",
     extraDescription: "The “cached” USD representation of our render-time procedurals in the shot. Merge this to see the fur & cloth on the animated characters.",
     type: "primary"
   }]

--- a/src/content/articles/alab.md
+++ b/src/content/articles/alab.md
@@ -5,7 +5,7 @@
 # Should the project show up on the home page
 show: true
 # The order the project card will show up on the home page
-order: 2
+order: 8
 # Image for the project card
 cardImage: {
   src: "../images/alab/alab-image001.gif",

--- a/src/content/articles/alab.md
+++ b/src/content/articles/alab.md
@@ -88,8 +88,8 @@ downloadSection: {
   # The download links and button setup for the download table.
   downloads: [{
     buttonText: "DOWNLOAD",
-    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-v2.2.0.zip",
-    size: "300 MB",
+    downloadUrl: "https://github.com/DigitalProductionExampleLibrary/ALab/archive/refs/tags/v2.2.0.zip",
+    size: "294 MB",
     description: "",
     descriptionBold: "Asset Structure - v.2.2.0 | ",
     extraDescription: "Main asset structure for the ALab showcasing how all assets relate to each other through USD composition arcs. This is purely the USD structure linking all files, and does not include any geometry, shaders or lights.",

--- a/src/content/articles/alab.md
+++ b/src/content/articles/alab.md
@@ -88,30 +88,47 @@ downloadSection: {
   # The download links and button setup for the download table.
   downloads: [{
     buttonText: "DOWNLOAD",
-    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-v2.1.0.zip",
+    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-v2.2.0.zip",
     size: "9.3 GB",
-    description: "USD Scene - v.2.1.0",
+    description: "",
+    descriptionBold: "Asset Structure | ",
+    extraDescription: "Main asset structure for the ALab showcasing how all assets relate to each other through USD composition arcs. This is purely the USD structure linking all files, and does not include any geometry, shaders or lights.",
     type: "primary"
   },
   {
     buttonText: "DOWNLOAD",
-    downloadUrl: "https://aswf-dpel-assets.s3.amazonaws.com/usd-alab/alab-textures.v2.1.0.zip",
+    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-v2.2.0.zip",
+    size: "8.9 GB",
+    description: "",
+    descriptionBold: "Techvar Assets | ",
+    extraDescription: "Assets holding the heavy creative content from DCCs (geometry, lights, shaders, textures, rigs), which Animal Logic refers to as 'techvar assets'. Merge this with the 'Asset Structure' package to render the ALab with 1k textures and without fur & cloth.",
+    type: "primary"
+  },
+  {
+    buttonText: "DOWNLOAD",
+    downloadUrl: "https://aswf-dpel-assets.s3.amazonaws.com/usd-alab/alab-textures.v2.2.0.zip",
     size: "71.4 GB",
-    description: "High Resolution Textures - v.2.1.0",
+    description: "",
+    descriptionBold: "Texture Pack | ",
+    extraDescription: "4k half float mipmapped OpenEXR textures in ACEScg color space. Merge this to see much higher quality for final rendering.",
     type: "primary"
   },
   {
     buttonText: "DOWNLOAD",
-    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-cameras.v2.1.0.zip",
+    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-cameras.v2.2.0.zip",
     size: "500 KB",
-    description: "Camera - v.2.1.0",
+    description: "",
+    descriptionBold: "Cameras | ",
+    extraDescription: "Cameras from the ALab Phase 2 trailer. Merge this to be able to select any trailer camera directly from the USD stage.",
     type: "primary"
   },             
   {
     buttonText: "DOWNLOAD",
-    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-procedurals.v2.1.0.zip",
+    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-procedurals.v2.2.0.zip",
     size: "18.1 GB",
-    description: "Baked Procedural Data - v.2.1.0",
+    description: "",
+    descriptionBold: "Baked Procedurals | ",
+    extraDescription: "The “cached” USD representation of our render-time procedurals in the shot. Merge this to see the fur & cloth on the animated characters.",
     type: "primary"
   }]
 }

--- a/src/content/articles/alab.md
+++ b/src/content/articles/alab.md
@@ -52,7 +52,9 @@ coverImage: {
 imageCaption: {
   # Text is separated by sections to allow links to be added in. <text> <link> <text>
   text: [
-    "A full production scene created by Animal Logic for exploration by the wider community to be used in demonstrations, training material, and in the testing of USD support across software and pipeline. ALab has over 300 assets, complete with high-quality textures and two characters with looping animation in shot context, expanding on the static scenes released to date.  Supplied as three separate downloads:  the full production scene, high-quality textures, and baked procedural fur and fabric for the animated characters. For more information, visit the ",
+    "A full production scene created by Animal Logic for exploration by the wider community to be used in demonstrations, training material, and in the testing of USD support across software and pipeline. ALab has over 300 assets, complete with high-quality textures and two characters with looping animation in shot context, expanding on the static scenes released to date. Supplied as separate downloads: the asset structure (available ", 
+    " as well), geometry / rigs / shaders assets, high-quality textures, and baked procedural fur and fabric for the animated characters. For more information, visit the ",
+    ", read the ",
     ", or join us on ", 
     "."
   ],
@@ -62,8 +64,16 @@ imageCaption: {
   #   link: ""
   # }
   textLinks: [{
+    text: "in GitHub",
+    link: "https://github.com/DigitalProductionExampleLibrary/ALab"
+  },
+  {
     text: "Animal Logic ALab website",
     link: "https://animallogic.com/alab/"
+  },
+  {
+    text: "technical documentation",
+    link: "https://digitalproductionexamplelibrary.github.io/ALab/main"
   },
   {
     text: "Slack.",


### PR DESCRIPTION
- Add description of the existing packages
- Updated links for the 2024 release (ALab-2.2.0)

Goes with https://github.com/DigitalProductionExampleLibrary/ALab/pull/6