### PR TITLE
AWS Airship Asset page, license, and image

### DIFF
--- a/src/content/articles/airship.md
+++ b/src/content/articles/airship.md
@@ -1,0 +1,134 @@
+---
+############################################################
+# Card view on home page
+############################################################
+# Should the project show up on the home page
+show: true
+# The order the project card will show up on the home page
+order: 9
+# Image for the project card
+cardImage: {
+  src: "../images/airship/airship_highRes.jpg",
+  alt: "AWS Airship Asset"
+}
+# The buttons that will show up on the project card
+buttons: [
+  {
+    text: "DOWNLOADS PAGE",
+    url: "airship",
+    type: "primary"
+  }
+]
+# The description of the project card
+description: "A complete animatable airship asset, with rig, geometry, textures, and surfacing, represented in Maya. The airship is featured in the short film Spanner, created by AWS’s in-house production team FuzzyPixel."
+
+############################################################
+# Article / Blog View
+############################################################
+# The layout file the blog page is using
+layout: "../../layout/BlogPostLayout3.astro"
+# Title of the blog page
+title: "AWS Airship Asset"
+# Used mainly for the Breadcrumbs
+titleAlt: "AWS Airship Asset"
+# The url of the blog page
+url: "airship"
+# The cover image of the blog page
+coverImage: {
+  src: "../images/airship/airship_highRes.jpg",
+  alt: "AWS Airship Asset",
+}
+# The image caption under the cover image
+imageCaption: {
+   # Text is separated by sections to allow links to be added in. <text> <link> <text>
+  text: ["The airship asset was showcased in Spanner, a short film produced by FuzzyPixel, an AWS creative team. FuzzyPixel specializes in rigorously testing cloud technologies, ensuring they meet the demanding standards of real-world production environments.",],
+  # Sample text links that would go in the caption if any. If not remove them like this:
+  # {
+  #   text: "",
+  #   link: ""
+  # }
+  textLinks: []
+}
+
+# Film link for Spanner
+filmLink: {
+  text: "Watch The film here!",
+  url: "https://vimeo.com/487443367"
+}
+
+# Asset info extra
+extraHeaderContent: {
+  subtext: "Created With:",
+  description: "Maya 2024",
+  extraDescription: "MtoA 5.3.5.1 Arnold Core 7.2.5.1",
+  secondSubtext: "Asset Size:",
+  secondDescription: "44.2 GB"
+}
+
+includedContentTop: {
+  title: "What's Included",
+  contentList: [   
+      { text: "Maya model file" },
+      { text: "Maya rig file" },
+      { text: "Maya surfacing file" },
+      { text: "Textures" },
+  ],
+  fileNotes: [
+    {
+      subtitle: "Rig File",
+      description: "The rig file references the low resolution airship model and contains a simple airship rig."
+    },
+    {
+      subtitle: "Surfacing",
+      description: "The surf file contains the high resolution airship model with UDIMS, high resolution textures, and materials applied."
+    },
+    {
+      subtitle: "Textures",
+      description: "High resolution textures organized by section of the airship."
+    },
+  ]
+}
+
+# Content list for Airship
+includedContentBottom: {
+  title: "Animate and Render the Airship",
+  contentList: [
+    {text: "(Optional) Reference the rig file into a new Maya file and save as the animation file."},
+    {text: "Create a performance with the rig."},
+    {text: "In Maya, go to the file menu and open the reference editor."},
+    {text: "In the reference editor, locate the reference called airshipLow.ma"},
+    {text: "Select the reference and right mouse click on it"},
+    {text: "Hover over 'Reference' and choose 'Replace Reference'"},
+    {text: "Navigate to the airship surfacing file: [PATH]/airship/surf/airship_surf.ma"},
+    {text: "Allow the high resolution, surfaced airship to load (this may take a few minutes)"},
+    {text: "Add lights to the scene and render"},
+  ]
+}
+
+# Credits for Airship asset
+credits: {
+  subtitle: "Credits",
+  list: [
+    "Created by FuzzyPixel, an AWS Creative Team",
+    "Modeling and Surfacing: Amaru Zeas",
+    "Rig: Nico Sanghrajka",
+  ]
+}
+
+# The download section of the blog
+downloadSection: {
+  title: "Downloadable Packages:",
+  subtext: "BY DOWNLOADING THESE FILES, YOU AGREE TO THE TERMS OF THE LICENSE LINKED BELOW.",
+  licenseButtonText: "ASWF Asset License",
+  licenseButtonLink: "airship/aws-airship-license",
+  tableHeader: "",
+  # The download links and button setup for the download table.
+  downloads: [{
+    buttonText: "DOWNLOAD",
+    downloadUrl: "https://dpel-assets.aswf.io/aws-spanner-asset-airship/aws-spanner-asset-airship-v1.0.zip",
+    size: "44.2 GB",
+    description: "AWS Airsihp Asset Zip",
+    type: "primary"
+  }]
+}
+---

--- a/src/content/articles/airship.md
+++ b/src/content/articles/airship.md
@@ -126,7 +126,7 @@ downloadSection: {
   downloads: [{
     buttonText: "DOWNLOAD",
     downloadUrl: "https://dpel-assets.aswf.io/aws-spanner-asset-airship/aws-spanner-asset-airship-v1.0.zip",
-    size: "44.2 GB",
+    size: "42.3 GB",
     description: "AWS Airsihp Asset Zip",
     type: "primary"
   }]

--- a/src/content/license/aws-airship-license.md
+++ b/src/content/license/aws-airship-license.md
@@ -1,0 +1,33 @@
+---
+# The layout file the blog page is using
+layout: "../../layout/LicenseLayout.astro"
+# Title of the license page
+title: "ASWF Digital Assets License v1.1"
+
+# Breadcrumb text
+titleAlt: "Airship License"
+blogTitleAlt: "AWS Airship Asset"
+
+# Links for the buttons: Back and Home
+homePageUrl: "/"
+previousPageUrl: "/aws-airship-asset"
+nextPageUrl: "/aws-airship-asset/aws-airship-license"
+
+# License text. Each sentence is broken up by commas.
+licenseContent: [
+  'License for AWS Airship Asset (the "Asset Name").',
+  "AWS Airship Asset Copyright 2024 Amazon Web Services. All rights reserved.",
+  "Redistribution and use of these digital assets, with or without modification, solely for education, training, research, software and hardware development, performance benchmarking (including publication of benchmark results and permitting reproducibility of the benchmark results by third parties), or software and hardware product demonstrations, are permitted provided that the following conditions are met:"
+]
+
+# License conditions. Each sentence is broken up by commas.
+licenseConditions: [
+  "Redistributions of these digital assets or any part of them must include the above copyright notice, this list of conditions and the disclaimer below, and if applicable, a description of how the redistributed versions of the digital assets differ from the originals.",
+  "Publications showing images derived from these digital assets must include the above copyright notice.",
+  "The names of copyright holder or the names of its contributors may NOT be used to promote or to imply endorsement, sponsorship, or affiliation with products developed or tested utilizing these digital assets or benchmarking results obtained from these digital assets, without prior written permission from copyright holder.",
+  "The assets and their output may only be referred to as the Asset Name listed above, and your use of the Asset Name shall be solely to identify the digital assets. Other than as expressly permitted by this License, you may NOT use any trade names, trademarks, service marks, or product names of the copyright holder for any purpose."
+]
+
+# License disclaimer text
+licenseDisclaimer: 'DISCLAIMER: THESE DIGITAL ASSETS ARE PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THESE DIGITAL ASSETS, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.'
+---

--- a/src/layout/BlogPostLayout3.astro
+++ b/src/layout/BlogPostLayout3.astro
@@ -1,0 +1,205 @@
+---
+/**
+ * This Layout is for the Airship asset page.
+ */
+
+// Components
+import Button from "../component/Button.astro";
+import Breadcrumbs from "../component/Breadcrumbs.astro";
+
+import { BASE_URL } from "../utils/constants";
+
+// Styles
+import "../styles/global.css";
+
+// Data from markdown
+const {
+  coverImage,
+  credits,
+  crumbs,
+  downloadSection,
+  extraHeaderContent,
+  filmLink,
+  imageCaption,
+  includedContentBottom,
+  includedContentTop,
+  title,
+  titleAlt,
+} = Astro.props;
+---
+
+<header class="pb-28 mt-20 text-center">
+  <Breadcrumbs titleAlt={titleAlt} crumbs={crumbs} />
+  <div class="header-content px-12">
+    <div class="pb-10">
+      <Button text="DPEL HOME PAGE" url={BASE_URL} type="primary" />
+    </div>
+    <h2>{title}</h2>
+    <p class="post-image-caption text-center py-12 desktop:mx-12 tablet:mx-5">
+      {imageCaption.text}
+    </p>
+    <img
+      class="w-full"
+      src={`${BASE_URL}${coverImage.src}`}
+      alt={coverImage.alt}
+    />
+
+    <p class="py-10"><a href={filmLink.url}>{filmLink.text}</a></p>
+
+    <div class="extra-header-content">
+      <b>{extraHeaderContent.subtext}</b>
+      <p>{extraHeaderContent.description}</p>
+      <p class="pb-5">{extraHeaderContent.extraDescription}</p>
+
+      <b>{extraHeaderContent.secondSubtext}</b>
+      {extraHeaderContent.secondDescription}
+
+      <p class="pt-12 pb-6 font-bold">{downloadSection.subtext}</p>
+      <Button
+        text={downloadSection.licenseButtonText}
+        type="primary"
+        url={downloadSection.licenseButtonLink}
+      />
+      {
+        downloadSection.downloads.map((download) => (
+          <Button
+            text={download.buttonText}
+            type="primary"
+            url={download.downloadUrl}
+          />
+        ))
+      }
+    </div>
+  </div>
+</header>
+
+<div class="post-content-preview container mx-auto px-20 pb-20">
+  <h3 class="pb-5">{includedContentTop.title}</h3>
+  <ul class="pl-3">
+    {
+      includedContentTop.contentList.map((item) => {
+        if (item.children) {
+          return (
+            <>
+              <li>{item.text}</li>
+              <ul>
+                {item.childrenText.map((child) => (
+                  <li class="pl-5">{child}</li>
+                ))}
+              </ul>
+            </>
+          );
+        } else {
+          return <li>{item.text}</li>;
+        }
+      })
+    }
+  </ul>
+  <p class="pt-8 pb-3"><i>{includedContentTop.note}</i></p>
+  {
+    includedContentTop.fileNotes.map((file) => (
+      <>
+        <p class="pt-7">
+          <b>{file.subtitle}</b>
+        </p>
+        <p>{file.description}</p>
+      </>
+    ))
+  }
+</div>
+<div class="post-content container mx-auto px-10">
+  <div
+    class="post-content-bottom container text-left mobile-h:px-5 mobile-v:px-5"
+  >
+    <h3 class="pb-5">{includedContentBottom.title}</h3>
+
+    <ul class="pl-3">
+      {
+        includedContentBottom.contentList.map((item) => {
+          if (item.children) {
+            return (
+              <>
+                <li>{item.text}</li>
+                <ul>
+                  {item.childrenText.map((child) => (
+                    <li class="pl-5">{child}</li>
+                  ))}
+                </ul>
+              </>
+            );
+          } else {
+            return <li>{item.text}</li>;
+          }
+        })
+      }
+    </ul>
+  </div>
+  <div class="post-content-credits pt-10">
+    <p>{credits.subtitle}</p>
+    {credits.list.map((credit) => <p>{credit}</p>)}
+  </div>
+  <slot />
+</div>
+
+<style>
+  .header-content {
+    background-image: url("/images/general/dpel-icon-faded.svg");
+    background-position: center;
+    background-color: #ffffff;
+    background-size: cover;
+  }
+
+  .post-content-preview ul,
+  .post-content-bottom ul {
+    list-style-type: disc;
+    list-style-position: inside;
+    line-height: 20px;
+  }
+
+  .post-content p,
+  .post-image-caption {
+    font-family: "Titillium Web", "Open Sans", sans-serif !important;
+    font-size: 20px;
+    font-weight: 300;
+    line-height: 28px;
+  }
+
+  .post-content h3,
+  .post-content-preview h3 {
+    font-size: 33px;
+    line-height: 35px;
+  }
+
+  .post-content-download {
+    font-family: "Open Sans", Helvetica, sans-serif !important;
+  }
+  .post-content-download h2 {
+    font-weight: 700 !important;
+    letter-spacing: 1px;
+  }
+  .post-content-download p {
+    font-size: 15px !important;
+    font-weight: 300;
+  }
+
+  .post-content-download .download-info {
+    font-size: 18px !important;
+    line-height: 24px;
+    color: #606060 !important;
+  }
+
+  .post-content-bottom p,
+  .post-content-credits p {
+    font-size: 15px;
+  }
+
+  .post-content-bottom p,
+  .post-content-credits p:first-child {
+    font-weight: bold;
+  }
+
+  .post-content-credits p:not(:first-child) {
+    font-family: "Open Sans", Helvetica, sans-serif !important;
+    font-weight: 400;
+  }
+</style>

--- a/src/pages/airship/aws-airship-license/index.astro
+++ b/src/pages/airship/aws-airship-license/index.astro
@@ -1,0 +1,19 @@
+---
+import { getEntryBySlug } from "astro:content";
+import LicenseLayout from "../../../layout/LicenseLayout.astro";
+import MainLayout from "../../../layout/MainLayout.astro";
+
+const content = await getEntryBySlug("license", "aws-airship-license");
+const parentContent = await getEntryBySlug("articles", 'airship');
+
+const crumbs = [
+  { text: parentContent.data.titleAlt, href: `/${parentContent.data.url}` },
+  { text: content.data.titleAlt },
+];
+---
+
+<MainLayout title={content.data.title}>
+  <div class="pb-32 container mx-auto">
+    <LicenseLayout {...content.data} crumbs={crumbs} />
+  </div>
+</MainLayout>

--- a/src/pages/airship/index.astro
+++ b/src/pages/airship/index.astro
@@ -1,0 +1,17 @@
+---
+import { getEntryBySlug } from "astro:content";
+
+// Layout
+import MainLayout from "../../layout/MainLayout.astro";
+import BlogPostLayout3 from "../../layout/BlogPostLayout3.astro";
+
+// Markdown
+const content = await getEntryBySlug("articles", "airship");
+const crumbs = [{ text: content.data.titleAlt }]
+---
+
+<MainLayout title={content.data.title}>
+  <div class="pb-32 container mx-auto">
+    <BlogPostLayout3 {...content.data} crumbs={crumbs} />
+  </div>
+</MainLayout>


### PR DESCRIPTION
Adds a new page for the AWS Airship asset.  The download URL is speculative, and will be updated if necessary once uploaded.

Also includes a new BlogPostLayout3 template that does not require `otherImages`, or child list items in `includedContentBottom.contenttList`

Contributing on behalf of AWS and @haleykannall