### PR TITLE
Update Table Layout for ALab to Blog4

### DIFF
--- a/src/component/Table2.astro
+++ b/src/component/Table2.astro
@@ -1,0 +1,75 @@
+---
+/**
+ * TABLE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * This component is used on the blog page for the download table.
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+
+// For the download buttons
+import Button from "./Button.astro";
+// Data for the table
+const { downloadData } = Astro.props;
+---
+
+<table class="text-left w-full table-auto">
+  <tbody>
+    {
+      downloadData.map((item) => (
+        <tr>
+          <td class="pl-2 pt-3">
+            {item.buttons.map((button) => (
+              <Button
+                frontmatter={button.frontmatter}
+                type={button.type ? button.type : "primary"}
+                text={button.text}
+                url={button.url}
+              />
+            ))}
+          </td>
+          <td class="pl-4">
+            {item.description}{" "}
+            {item.descriptionBold ? (
+              <text>
+                <b>{item.descriptionBold}</b>
+              </text>
+              <br>
+              <text>
+                {item.extraDescription}
+              </text>
+            ) : null}
+          </td>
+          <td class="pl-4">
+            <p class="hash">{item.hashA}</p>
+            <>
+              <p>{item.size}</p>
+              <p class="hash">{item.hashB}</p>
+            </>
+          </td>
+        </tr>
+      ))
+    }
+  </tbody>
+</table>
+
+<style>
+  table {
+    border: 1px solid #000000;
+    color: #000000;
+  }
+  td {
+    border: 1px solid #000000;
+    background: #ffffff;
+  }
+  tr td:first-child() {
+    width: 100px;
+  }
+  tr td:nth-child(3) {
+    width: 130px;
+  }
+  .hash {
+    font-weight: 300;
+    font-size: 12px;
+  }
+</style>

--- a/src/content/articles/alab.md
+++ b/src/content/articles/alab.md
@@ -19,8 +19,8 @@ buttons: [
     type: "primary"
   },
   {
-    text: "PROJECT HOME",
-    url: "https://animallogic.com/alab",
+    text: "GITHUB REPOSITORY",
+    url: "https://github.com/DigitalProductionExampleLibrary/ALab",
     type: "primary"
   },
 ]
@@ -36,7 +36,7 @@ descriptionLinks: {
 ############################################################
 
 # The layout file the blog page is using
-layout: "../../layout/BlogPostLayout.astro"
+layout: "../../layout/BlogPostLayout4.astro"
 # Title of the blog page
 title: "Animal Logic ALab - USD Production Scene"
 # Used mainly for the Breadcrumbs
@@ -97,49 +97,66 @@ downloadSection: {
 
   # The download links and button setup for the download table.
   downloads: [{
-    buttonText: "DOWNLOAD",
-    downloadUrl: "https://github.com/DigitalProductionExampleLibrary/ALab/archive/refs/tags/v2.2.0.zip",
+    buttons: [
+      {
+        text: "GITHUB REPOSITORY",
+        url: "https://github.com/DigitalProductionExampleLibrary/ALab",
+        type: "primary",
+      },
+      {
+        text: "DOWNLOAD",
+        url: "https://github.com/DigitalProductionExampleLibrary/ALab/archive/refs/tags/v2.2.0.zip",
+        type: "primary",
+      }
+    ],
     size: "294 MB",
     description: "",
-    descriptionBold: "Asset Structure - v.2.2.0 | ",
-    extraDescription: "Main asset structure for the ALab showcasing how all assets relate to each other through USD composition arcs. This is purely the USD structure linking all files, and does not include any geometry, shaders or lights.",
-    type: "primary"
+    descriptionBold: "Asset Structure - v.2.2.0",
+    extraDescription: "Main asset structure for the ALab showcasing how all assets relate to each other through USD composition arcs. This is purely the USD structure linking all files, and does not include any geometry, shaders or lights.  Clone the GitHub repository, or download the Zip artifact from the GitHub Release.",
   },
   {
-    buttonText: "DOWNLOAD",
-    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-techvars.v2.2.0.zip",
+    buttons: [{
+      text: "DOWNLOAD",
+      url: "https://dpel-assets.aswf.io/usd-alab/alab-techvars.v2.2.0.zip",
+      type: "primary",
+    }],
     size: "8.9 GB",
     description: "",
-    descriptionBold: "Techvar Assets - v.2.2.0 | ",
+    descriptionBold: "Techvar Assets - v.2.2.0",
     extraDescription: "Assets holding the heavy creative content from DCCs (geometry, lights, shaders, textures, rigs), which Animal Logic refers to as 'techvar assets'. Merge this with the 'Asset Structure' package to render the ALab with 1k textures and without fur & cloth.",
-    type: "primary"
   },
   {
-    buttonText: "DOWNLOAD",
-    downloadUrl: "https://aswf-dpel-assets.s3.amazonaws.com/usd-alab/alab-textures.v2.2.0.zip",
+    buttons: [{
+      text: "DOWNLOAD",
+      url: "https://aswf-dpel-assets.s3.amazonaws.com/usd-alab/alab-textures.v2.2.0.zip",
+      type: "primary",
+    }],
     size: "71.4 GB",
     description: "",
-    descriptionBold: "Texture Pack - v.2.2.0 | ",
+    descriptionBold: "Texture Pack - v.2.2.0",
     extraDescription: "4k half float mipmapped OpenEXR textures in ACEScg color space. Merge this to see much higher quality for final rendering.",
-    type: "primary"
   },
   {
-    buttonText: "DOWNLOAD",
-    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-cameras.v2.2.0.zip",
+    buttons: [{
+      text: "DOWNLOAD",
+      url: "https://dpel-assets.aswf.io/usd-alab/alab-cameras.v2.2.0.zip",
+      type: "primary",
+    }],
     size: "500 KB",
     description: "",
-    descriptionBold: "Cameras - v.2.2.0 | ",
+    descriptionBold: "Cameras - v.2.2.0",
     extraDescription: "Cameras from the ALab Phase 2 trailer. Merge this to be able to select any trailer camera directly from the USD stage.",
-    type: "primary"
   },             
   {
-    buttonText: "DOWNLOAD",
-    downloadUrl: "https://dpel-assets.aswf.io/usd-alab/alab-procedurals.v2.2.0.zip",
+    buttons: [{
+      text: "DOWNLOAD",
+      url: "https://dpel-assets.aswf.io/usd-alab/alab-procedurals.v2.2.0.zip",
+      type: "primary",
+    }],
     size: "18.1 GB",
     description: "",
-    descriptionBold: "Baked Procedurals - v.2.2.0 | ",
+    descriptionBold: "Baked Procedurals - v.2.2.0",
     extraDescription: "The “cached” USD representation of our render-time procedurals in the shot. Merge this to see the fur & cloth on the animated characters.",
-    type: "primary"
   }]
 }
 ---

--- a/src/layout/BlogPostLayout4.astro
+++ b/src/layout/BlogPostLayout4.astro
@@ -1,0 +1,92 @@
+---
+// General blog page layout
+import Button from "../component/Button.astro";
+import Table from "../component/Table2.astro";
+import Breadcrumbs from "../component/Breadcrumbs.astro";
+import '../styles/global.css'
+
+import {BASE_URL} from '../utils/constants'
+
+// Data from markdown
+const {
+  coverImage,
+  crumbs,
+  downloadSection,
+  imageCaption,
+  otherImages,
+  title,
+  titleAlt,
+} = Astro.props;
+---
+<header class="pb-28 mt-20 text-center">
+  <Breadcrumbs titleAlt={titleAlt} crumbs={crumbs} />
+  <div class="pb-10">
+    <Button text="DPEL HOME PAGE" url={BASE_URL} type="primary" />
+  </div>
+  <h2 class="mobile-v:px-5 mobile-h:px-5">{title}</h2>
+</header>
+<div class="post-content container mx-auto px-10">
+  <img class="w-full" width="1300" height="1000" src={`${BASE_URL}${coverImage.src}`} alt={coverImage.alt} />
+  <p class="post-image-caption text-center py-12">
+    {imageCaption.text && imageCaption.textLinks && imageCaption.textLinks.map((item, i)=> (
+      <span>{imageCaption.text[i]}
+        <a href={imageCaption.textLinks[i].link} target="_blank" rel="noreferrer noopener">
+          {imageCaption.textLinks[i].text}
+        </a>
+      </span>
+    ))}
+  </p>
+  <div class="post-content-images mb-32 grid gap-5 desktop:grid-cols-2 tablet:grid-cols-2 mobile-h:grid-cols-1 mobile-v:grid-cols-1">
+    { otherImages &&
+      otherImages.map(image => (
+      <img src={`${BASE_URL}${image}`} />
+      ))
+    }
+  </div>
+  <div class="post-content-download container mx-auto desktop:px-40 tablet:px-40 mobile-h:px-5 mobile-v:px-5 text-center">
+    <h2 class="pb-5">{downloadSection.title}</h2>
+    <p class="pb-6">{downloadSection.subtext}</p>
+    <Button text={downloadSection.licenseButtonText} type="secondary" url={`${BASE_URL}${downloadSection.licenseButtonLink}`} />
+    <p class="download-info pt-24 desktop:mx-40 pb-10">For large downloads, it is recommended to use a command-line tool
+      such as <strong>wget</strong> or <strong>curl</strong>. In most
+      browsers, you can right-mouse on the download link to copy the URL. Then
+      open a Command or Terminal window, and run the command <strong>wget
+      &lt;URL&gt;</strong>, or <strong>curl -L -O &lt;URL&gt;</strong>, where &lt;URL&gt; is
+      replaced with the download link. To resume an interrupted download, try
+      <strong>wget -c &lt;URL&gt;</strong> or <strong>curl -L -O -C -
+      &lt;URL&gt;</strong>.
+    </p>
+    { downloadSection.tableHeader && <h3 class="text-left pb-7">{downloadSection.tableHeader}</h3> }
+    <Table downloadData={downloadSection.downloads} />
+  </div>
+  <slot />
+</div>
+
+<style>
+.post-content p {
+  font-family: "Titillium Web", "Open Sans", sans-serif !important;
+  font-size: 20px;
+  font-weight: 300;
+  line-height: 28px;
+}
+
+.post-content-download {
+  font-family: 'Open Sans', Helvetica, sans-serif !important;
+}
+.post-content-download h2 {
+  font-weight: 700 !important;
+  letter-spacing: 1px;
+}
+.post-content-download p {
+  font-size: 15px !important;
+  font-weight: 300;
+}
+
+.post-content-download .download-info {
+  font-size: 18px !important;
+  line-height: 24px;
+  color: #606060 !important;
+}
+
+
+</style>

--- a/src/pages/alab/index.astro
+++ b/src/pages/alab/index.astro
@@ -2,7 +2,7 @@
 import { getEntryBySlug } from 'astro:content';
 
 import MainLayout from "../../layout/MainLayout.astro";
-import BlogPostLayout from "../../layout/BlogPostLayout.astro";
+import BlogPostLayout from "../../layout/BlogPostLayout4.astro";
 
 const content = await getEntryBySlug('articles', 'alab');
 const crumbs = [{ text: content.data.titleAlt }]


### PR DESCRIPTION
Modifies the ALab downloads page to use a new `BlogPostLayout4.astro`, which uses a new `Table2.astro`, which supports multiple download buttons and multi-line descriptions in the downloads table.

Also updates the link on the DPEL home page to the new GitHub repo.

FTI @chrizzFTD 