### PR TITLE
Rebrand Animal Logic to Netflix Animation Studios

### DIFF
--- a/src/content/articles/alab-trailer.md
+++ b/src/content/articles/alab-trailer.md
@@ -37,7 +37,7 @@ descriptionLinks: {
 # The layout file the blog page is using
 layout: "../../layout/BlogPostLayout2.astro"
 # Title of the blog page
-title: "Animal Logic ALab - Trailer"
+title: "Netflix Animation Studios ALab - Trailer"
 # Used mainly for the Breadcrumbs
 titleAlt: "ALab Trailer"
 # The url of the blog page
@@ -50,7 +50,7 @@ coverImage: {
 # The image caption under the cover image
 imageCaption: {
   # Text is separated by sections to allow text links to be added in between. <text> <link> <text>
-  text: ["Following the release of the ALab asset set, Animal Logic has released the ", " trailer as its own asset. Initially provided natively for both Avid and ", " and with full media and mixed audio, the community is encouraged to use these assets in demonstrations, training material, and in any context where timeline-based media examples would be useful. For more information, visit the ",", or join us on "],
+  text: ["Following the release of the ALab asset set, Netflix Animation Studios has released the ", " trailer as its own asset. Initially provided natively for both Avid and ", " and with full media and mixed audio, the community is encouraged to use these assets in demonstrations, training material, and in any context where timeline-based media examples would be useful. For more information, visit the ",", or join us on "],
   # Sample text links that would go in the caption if any. If not remove them like this:
   # {
   #   text: "",
@@ -66,7 +66,7 @@ imageCaption: {
     link: "https://opentimeline.io/"
   },
   {
-    text: "Animal Logic ALab website",
+    text: "Netflix Animation Studios ALab website",
     link: "https://animallogic.com/alab/"
   },
   {

--- a/src/content/articles/alab.md
+++ b/src/content/articles/alab.md
@@ -27,7 +27,7 @@ buttons: [
 # The description of the project card
 description: "A full production scene with over 300 assets and two characters, with looping animation in the first open-sourced USD scene and shot context from a studio. Supplied as three separate downloads: the full production scene, high-quality textures, and baked procedural fur and fabric for the animated characters. For more information, visit the "
 descriptionLinks: {
-  text: "Animal Logic ALab website.",
+  text: "Netflix Animation Studios ALab website.",
   url: "https://animallogic.com/alab"
 }
 
@@ -38,7 +38,7 @@ descriptionLinks: {
 # The layout file the blog page is using
 layout: "../../layout/BlogPostLayout4.astro"
 # Title of the blog page
-title: "Animal Logic ALab - USD Production Scene"
+title: "Netflix Animation Studios ALab - USD Production Scene"
 # Used mainly for the Breadcrumbs
 titleAlt: "ALab"
 # The url of the blog page
@@ -52,7 +52,7 @@ coverImage: {
 imageCaption: {
   # Text is separated by sections to allow links to be added in. <text> <link> <text>
   text: [
-    "A full production scene created by Animal Logic for exploration by the wider community to be used in demonstrations, training material, and in the testing of USD support across software and pipeline. ALab has over 300 assets, complete with high-quality textures and two characters with looping animation in shot context, expanding on the static scenes released to date. Supplied as separate downloads: the asset structure (available ", 
+    "A full production scene created by Netflix Animation Studios for exploration by the wider community to be used in demonstrations, training material, and in the testing of USD support across software and pipeline. ALab has over 300 assets, complete with high-quality textures and two characters with looping animation in shot context, expanding on the static scenes released to date. Supplied as separate downloads: the asset structure (available ", 
     " as well), geometry / rigs / shaders assets, high-quality textures, and baked procedural fur and fabric for the animated characters. For more information, visit the ",
     ", read the ",
     ", or join us on ", 
@@ -68,7 +68,7 @@ imageCaption: {
     link: "https://github.com/DigitalProductionExampleLibrary/ALab"
   },
   {
-    text: "Animal Logic ALab website",
+    text: "Netflix Animation Studios ALab website",
     link: "https://animallogic.com/alab/"
   },
   {
@@ -123,7 +123,7 @@ downloadSection: {
     size: "8.9 GB",
     description: "",
     descriptionBold: "Techvar Assets - v.2.2.0",
-    extraDescription: "Assets holding the heavy creative content from DCCs (geometry, lights, shaders, textures, rigs), which Animal Logic refers to as 'techvar assets'. Merge this with the 'Asset Structure' package to render the ALab with 1k textures and without fur & cloth.",
+    extraDescription: "Assets holding the heavy creative content from DCCs (geometry, lights, shaders, textures, rigs), which Netflix Animation Studios refers to as 'techvar assets'. Merge this with the 'Asset Structure' package to render the ALab with 1k textures and without fur & cloth.",
   },
   {
     buttons: [{

--- a/src/content/homecards/new-assets.md
+++ b/src/content/homecards/new-assets.md
@@ -3,7 +3,7 @@
 # New Assets Card view on home page under News section
 ############################################################
 title: "New Assets"
-description: "New from Intel, an indoor-outdoor 3D scene with challenging ray tracing scenarios.  And for you non-linear editing fans, Animal Logic has provided the full edit list and media clips for the ALab promotional trailer. Links below!"
+description: "New from Intel, an indoor-outdoor 3D scene with challenging ray tracing scenarios.  And for you non-linear editing fans, Netflix Animation Studios has provided the full edit list and media clips for the ALab promotional trailer. Links below!"
 link: {
   text: "",
   url: ""

--- a/src/content/license/alab-license.md
+++ b/src/content/license/alab-license.md
@@ -15,8 +15,8 @@ nextPageUrl: "/alab/alab-license"
 
 # License text. Each sentence is broken up by commas.
 licenseContent: [
-  'License for Animal Logic ALab (the "Asset Name").',
-  "Animal Logic ALab Copyright 2024 Animal Logic Pty Limited. All rights reserved.",
+  'License for Netflix Animation Studios ALab (the "Asset Name").',
+  "Netflix Animation Studios ALab Copyright 2025 Netflix, Inc. All rights reserved.",
   "Redistribution and use of these digital assets, with or without modification, solely for education, training, research, software and hardware development, performance benchmarking (including publication of benchmark results and permitting reproducibility of the benchmark results by third parties), or software and hardware product demonstrations, are permitted provided that the following conditions are met:"
 ]
 

--- a/src/content/license/alab-trailer-license.md
+++ b/src/content/license/alab-trailer-license.md
@@ -9,8 +9,8 @@ previousPageUrl: "/alab-trailer"
 nextPageUrl: "/alab-trailer/alab-trailer-license"
 
 licenseContent: [
-  'License for Animal Logic ALab (the "Asset Name").',
-  "Animal Logic ALab Copyright 2022 Animal Logic Pty Limited. All rights reserved.",
+  'License for Netflix Animation Studios ALab (the "Asset Name").',
+  "Netflix Animation Studios ALab Copyright 2025 Netflix, Inc. All rights reserved.",
   "Redistribution and use of these digital assets, with or without modification, solely for education, training, research, software and hardware development, performance benchmarking (including publication of benchmark results and permitting reproducibility of the benchmark results by third parties), or software and hardware product demonstrations, are permitted provided that the following conditions are met:"
 ]
 


### PR DESCRIPTION
Per discussions with the original asset contributors, Animal Logic has completed its internal transition to Netflix Animation Studios, and wants this rebrand to be reflected on its DEPL contributions, the ALab and the ALab Trailer assets.